### PR TITLE
perf: optimise unpublished_measurements query

### DIFF
--- a/telegraf.conf
+++ b/telegraf.conf
@@ -185,12 +185,17 @@
   sqlquery="SELECT * FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 1"
   tagvalue=""
 
-# [[inputs.postgresql_extensible.query]]
-#   measurement="unpublished_measurements"
-#   sqlquery='''
-#     SELECT
-#       COUNT(*) AS total_count,
-#       FLOOR(EXTRACT(epoch FROM (now() - MIN(finished_at))))::INTEGER AS max_age_in_seconds
-#     FROM measurements
-#   '''
-#   tagvalue=""
+[[inputs.postgresql_extensible.query]]
+  measurement="unpublished_measurements"
+  sqlquery='''
+    SELECT
+      COUNT(*) AS total_count,
+      FLOOR(EXTRACT(epoch FROM (now() - MIN(finished_at))))::INTEGER AS max_age_in_seconds
+    FROM (
+      SELECT finished_at FROM measurements
+      WHERE finished_at IS NOT NULL
+      ORDER BY finished_at ASC
+      LIMIT 10000000
+    ) t;
+  '''
+  tagvalue=""

--- a/telegraf.conf
+++ b/telegraf.conf
@@ -193,7 +193,6 @@
       FLOOR(EXTRACT(epoch FROM (now() - MIN(finished_at))))::INTEGER AS max_age_in_seconds
     FROM (
       SELECT finished_at FROM measurements
-      WHERE finished_at IS NOT NULL
       ORDER BY finished_at ASC
       LIMIT 10000000
     ) t;


### PR DESCRIPTION
Requires https://github.com/filecoin-station/voyager-api/pull/29 to be deployed first.

Reverts 4994efbe7

```
EXPLAIN 
SELECT
  COUNT(*) AS total_count,
  FLOOR(EXTRACT(epoch FROM (now() - MIN(finished_at))))::INTEGER AS max_age_in_seconds
FROM (
  SELECT finished_at FROM measurements
  ORDER BY finished_at ASC
  LIMIT 10000000
) t;

Aggregate  (cost=828.29..828.31 rows=1 width=12)
  ->  Limit  (cost=0.29..528.29 rows=20000 width=8)
        ->  Index Only Scan using measurements_finished_at on measurements  
            (cost=0.29..528.29 rows=20000 width=8)
```
